### PR TITLE
add support for user specified vector scale. add colorscalerange and …

### DIFF
--- a/wms/mpl_handler.py
+++ b/wms/mpl_handler.py
@@ -84,6 +84,7 @@ def quiver_response(lon,
                     dx,
                     dy,
                     request,
+                    vectorscale,
                     unit_vectors=False,
                     dpi=80):
 
@@ -121,9 +122,9 @@ def quiver_response(lon,
 
     # plot unit vectors
     if unit_vectors:
-        ax.quiver(x, y, dx/mags, dy/mags, mags, cmap=cmap)
+        ax.quiver(x, y, dx/mags, dy/mags, mags, cmap=cmap, scale=vectorscale)
     else:
-        ax.quiver(x, y, dx, dy, mags, cmap=cmap, norm=norm)
+        ax.quiver(x, y, dx, dy, mags, cmap=cmap, norm=norm, scale=vectorscale)
 
     ax.set_xlim(bbox.minx, bbox.maxx)
     ax.set_ylim(bbox.miny, bbox.maxy)

--- a/wms/templates/wms/demo.html
+++ b/wms/templates/wms/demo.html
@@ -58,12 +58,13 @@
 
     // one layer per dataset, we'll modify the layer and style with the click
     {% for dataset in datasets %}
+    var wmsURL = "{% url 'dataset' dataset.slug %}";
     var {{dataset.slug}} = L.tileLayer.wms("{% url 'dataset' dataset.slug %}", {
         format: 'image/png',
         transparent: 'true',
         attribution: "Sci-wms - Python WMS service",
         opacity: 0.7,
-    });
+    })
     {% endfor %}
 
     var bounds = new L.LatLngBounds(new L.LatLng(32, -126), new L.LatLng(50, -64));
@@ -76,13 +77,24 @@
         dataset_slug = $(this).data('dataset');
         layer = $(this).data('layer');
         style = $(this).data('style');
-
-        l = eval(dataset_slug);
-        l.setParams({
-            layers: layer,
-            styles: style
-        });
-
+		vectors = style.indexOf('vectors');
+		l = eval(dataset_slug);
+		var colorscale = '0,1';
+		if (vectors >= 0) {
+	        l.setParams({
+	            layers: layer,
+	            styles: style,
+	            colorscalerange: colorscale,
+	            vectorscale: 20
+	        });			
+		}
+		else {
+	        l.setParams({
+	            layers: layer,
+	            styles: style,
+	            colorscalerange: colorscale
+	        });				
+		}
         // -- clear existing layers
         displayed_layers.clearLayers();
         // -- add this layer

--- a/wms/tests/test_utils.py
+++ b/wms/tests/test_utils.py
@@ -1,0 +1,71 @@
+'''
+Created on Jul 21, 2015
+
+@author: ayan
+'''
+import unittest
+import numpy as np
+
+from ..utils import (adjacent_array_value_differences, calc_safety_factor,
+                     calc_lon_lat_padding)
+
+
+class TestAdjacentArrayValueDifferences(unittest.TestCase):
+    
+    def setUp(self):
+        self.test_data = [(1.5, 3, 4, 6.5),
+                          (2.3, 4.5, 9.6, 10)
+                          ]
+        self.test_array = np.array(self.test_data)
+        
+    def test_adj_arr_diff(self):
+        result = adjacent_array_value_differences(self.test_array)
+        expected_data = [(-1.5, -1, -2.5),
+                         (-2.2, -5.1, -0.4)
+                         ]
+        expected_array = np.array(expected_data)
+        np.testing.assert_almost_equal(result, expected_array, decimal=2)
+        
+        
+class TestCalcSafetyFactor(unittest.TestCase):
+    
+    def setUp(self):
+        self.low_value = 0.5
+        self.high_value = 1000
+        
+    def test_calc_with_low_value(self):
+        result = calc_safety_factor(self.low_value)
+        expected = 2195.6896
+        self.assertAlmostEqual(result, expected, 3)
+        
+    def test_calc_with_high_value(self):
+        result = calc_safety_factor(self.high_value)
+        expected = 10
+        self.assertEqual(result, expected)
+        
+        
+class TestCalcLonLatPadding(unittest.TestCase):
+    
+    def setUp(self):
+        self.lon_data = [(-74.5, -75.0, -75.5, -76.0),
+                         (-74.3, -74.8, -75.3, -75.8)
+                         ]
+        self.lat_data_small = [(14.2, 14.4, 14.6, 14.8),
+                               (14.3, 14.5, 14.7, 14.9)
+                               ]
+        self.lat_data_large = [(14.1, 14.7, 15.3, 15.9),
+                               (15.2, 15.8, 16.4, 17.0)
+                               ]
+        self.lon_array = np.array(self.lon_data)
+        self.lat_array_small = np.array(self.lat_data_small)
+        self.lat_array_large = np.array(self.lat_data_large)
+        
+    def test_large_lon_delta(self):
+        result = calc_lon_lat_padding(self.lon_array, self.lat_array_small)
+        expected = 5.0
+        self.assertAlmostEqual(result, expected, 3)
+        
+    def test_large_lat_delta(self):
+        result = calc_lon_lat_padding(self.lon_array, self.lat_array_large)
+        expected = 11
+        self.assertAlmostEqual(result, expected, 3)

--- a/wms/utils.py
+++ b/wms/utils.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import numpy as np
 
 from wms import logger
 
@@ -17,7 +18,63 @@ def get_layer_from_request(dataset, request):
         return (list(layer_objects) + list(virtuallayer_objects))[0]
     except IndexError:
         raise ValueError("No layer or virtuallayer named {} found on dataset".format(requested_layers))
+    
+    
+def adjacent_array_value_differences(np_array):
+    """
+    Calculate the differences between
+    adjacent values in a numpy array.
+    
+    """
+    a_1 = np_array[..., 1:]
+    a_0 = np_array[..., :-1]
+    delta_a = a_0 - a_1
+    return delta_a
 
+
+def calc_lon_lat_padding(lon_array, lat_array, safety_factor=10):
+    """
+    Calculate the padding to be used when
+    determining a spatial index. A fudge factor
+    is applied to ensure that the necessary data
+    is grab. 
+    
+    This is particularly useful when plotting
+    vectors, as they may be cut off depending on the
+    scale used. Having a larger padding means
+    that a tile is initially created with data
+    that exists in another tile before being trimed
+    to size. This avoids the appearance of seems
+    in tile layer responses.
+    
+    """
+    delta_lon = adjacent_array_value_differences(lon_array)
+    delta_lat = adjacent_array_value_differences(lat_array.T)
+    average_delta_lon = np.average(delta_lon)
+    average_delta_lat = np.average(delta_lat)
+    abs_avg_delta_lon = np.absolute(average_delta_lon)
+    abs_avg_delta_lat = np.absolute(average_delta_lat)
+    if abs_avg_delta_lon > abs_avg_delta_lat:
+        calculated_padding = abs_avg_delta_lon * safety_factor
+    else:
+        calculated_padding = abs_avg_delta_lat * safety_factor
+    return calculated_padding
+    
+    
+def calc_safety_factor(requested_vector_scale):
+    """
+    Calculate an appropriate fudge factor
+    based on vector_scale. Smaller requested_vector_scale
+    will require a larger fudge factor.
+    
+    """
+    # figured out this function by inspection
+    sf = 802 * requested_vector_scale ** -1.453
+    if sf < 10:
+        return 10
+    else:
+        return sf
+    
 
 def find_appropriate_time(var_obj, time_variables):
     """

--- a/wms/views.py
+++ b/wms/views.py
@@ -476,6 +476,7 @@ def enhance_getmap_request(dataset, layer, request):
         height=dimensions.height,
         image_type=wms_handler.get_imagetype(request),
         logscale=wms_handler.get_logscale(request, defaults.logscale),
+        vectorscale=wms_handler.get_vectorscale(request)
     )
     gettemp.update(newgets)
     request.GET = gettemp

--- a/wms/wms_handler.py
+++ b/wms/wms_handler.py
@@ -196,6 +196,17 @@ def get_imagetype(request, parameter=None):
         return request.GET.get(parameter).split(',')[0].split('_')[0].lower()
     except (AttributeError, TypeError):
         return 'filledcontours'
+    
+    
+def get_vectorscale(request):
+    try:
+        vectorscale = float(request.GET.get('vectorscale'))
+    except (AttributeError, TypeError):
+        if get_imagetype(request) == 'vectors':
+            vectorscale = 20  # this seems a reasonable number
+        else:
+            vectorscale = None  # don't bother with a default if vectors aren't being plotted
+    return vectorscale
 
 
 def get_colorscalerange(request, default_min, default_max):


### PR DESCRIPTION
…vector scale parameters to leaflet demo

Pull request to address #51 

A `vectorscale` parameter is now supported that allows a user to specify scale of the vector. The number is passed the matplotlib's `quiver` method as the `scale` keyword and follows the the same convention. Hence. large values of `vectorscale` give smaller vectors, while small values give longer vectors. These changes have been implemented for both `sgrid` and `ugrid` models.

A consequence of this change is the padding used in spatial indexing is calculated based on the `vectorscale` value. This prevents vectors from being cutoff between tiles in the leaflet client and hence reduces the appearance of seems. The functions that support this are in the `utils` module. In addition, a `colorscalerange` is specified when the leaflet client makes a tile request... again reduces the appearance of seams.

The choice of `vectorscale` was influenced by this discussion: http://sourceforge.net/p/ncwms/mailman/message/32091284/. There was also a propose to use the a `ppu` keyword in the `style` parameter per http://www.resc.rdg.ac.uk/trac/ncWMS/ticket/65, but it they decided not to use it.

![sciwms_leaflet_client_20150721](https://cloud.githubusercontent.com/assets/1903370/8808387/e3dacbbc-2fa7-11e5-8d2b-cf79d4a62c20.png)
