### PR TITLE
vectorstep option for issue #60

### DIFF
--- a/wms/tests/test_sgrid.py
+++ b/wms/tests/test_sgrid.py
@@ -92,7 +92,7 @@ class TestSgrid(TestCase):
         params.update(styles='filledcontours_jet')
         self.do_test(params)
 
-    @xfail(reason="facets is not yet implemeted for SGRID datasets")
+    @xfail(reason="facets is not yet implemented for SGRID datasets")
     def test_facets(self):
         params = copy(self.url_params)
         params.update(styles='facets_jet')
@@ -103,7 +103,7 @@ class TestSgrid(TestCase):
         params.update(styles='pcolor_jet')
         self.do_test(params)
 
-    @xfail(reason="contours is not yet implemeted for SGRID datasets")
+    @xfail(reason="contours is not yet implemented for SGRID datasets")
     def test_contours(self):
         params = copy(self.url_params)
         params.update(styles='contours_jet')
@@ -112,6 +112,16 @@ class TestSgrid(TestCase):
     def test_vectors(self):
         params = copy(self.url_params)
         params.update(styles='vectors_jet', layers='u,v')
+        self.do_test(params)
+        
+    def test_sgrid_vectorscale(self):
+        params = copy(self.url_params)
+        params.update(vectorscale=25, styles='vectors_jet', layers='u,v')
+        self.do_test(params)
+        
+    def test_sgrid_vectorstep(self):
+        params = copy(self.url_params)
+        params.update(vectorstep=5, styles='vectors_jet', layers='u,v')
         self.do_test(params)
 
     def test_sgrid_gfi_single_variable_csv(self):

--- a/wms/tests/test_ugrid.py
+++ b/wms/tests/test_ugrid.py
@@ -131,6 +131,22 @@ class TestUgrid(TestCase):
         params = copy(self.gmd_params)
         params['item']  = 'minmax'
         self.do_test(params, fmt='json')
+    
+    @xfail(reason='current ugrid test dataset does contain a vector variable')  
+    def test_ugrid_vectorscale(self):
+        params = copy(self.url_params)
+        params['vectorscale'] = 25
+        params['styles'] = 'vectors_jet'
+        params['layers'] = 'u,v'
+        self.do_test(params)
+    
+    @xfail(reason='current ugrid test dataset does contain a vector variable')
+    def test_ugrid_vectorstep(self):
+        params = copy(self.url_params)
+        params['vectorstep'] = 5
+        params['styles'] = 'vectors_jet'
+        params['layers'] = 'u,v'
+        self.do_test(params)
 
     def test_getCaps(self):
         params = dict(request='GetCapabilities')

--- a/wms/views.py
+++ b/wms/views.py
@@ -126,7 +126,8 @@ def enhance_getmap_request(dataset, layer, request):
         height=dimensions.height,
         image_type=wms_handler.get_imagetype(request),
         logscale=wms_handler.get_logscale(request, defaults.logscale),
-        vectorscale=wms_handler.get_vectorscale(request)
+        vectorscale=wms_handler.get_vectorscale(request),
+        vectorstep=wms_handler.get_vectorstep(request)
     )
     gettemp.update(newgets)
     request.GET = gettemp

--- a/wms/wms_handler.py
+++ b/wms/wms_handler.py
@@ -209,6 +209,17 @@ def get_vectorscale(request):
     return vectorscale
 
 
+def get_vectorstep(request):
+    try:
+        vectorstep = int(request.GET.get('vectorstep'))
+    except TypeError:
+        if get_imagetype(request) == 'vectors':
+            vectorstep = 1  # equivalent to getting all the data
+        else:
+            vectorstep = None
+    return vectorstep
+
+
 def get_colorscalerange(request, default_min, default_max):
     try:
         climits = sorted([ float(x) for x in request.GET.get('colorscalerange').split(',') ])


### PR DESCRIPTION
Added a `vectorstep` option for sgrid and ugrid datasets per #60. I'll update the documentation once this PR is merged.

As an aside, do we want a sample ugrid dataset that has vector data?
