### PR TITLE
Avoid problems with dashes in JavaScript variables (still ugly JS...)

### DIFF
--- a/wms/models/datasets/base.py
+++ b/wms/models/datasets/base.py
@@ -16,6 +16,7 @@ from wms.models import VirtualLayer, Layer, Style
 from django.conf import settings
 from django.http.response import HttpResponse
 from autoslug import AutoSlugField
+from autoslug.settings import slugify as default_slugify
 
 import rtree
 
@@ -24,6 +25,10 @@ from wms.data_handler import blank_canvas
 from wms import glg_handler
 
 from wms import logger
+
+
+def only_underscores(value):
+    return default_slugify(value).replace('-', '_')
 
 
 class Dataset(TypedModel):
@@ -35,7 +40,7 @@ class Dataset(TypedModel):
     display_all_timesteps = models.BooleanField(help_text="Check this box to display each time step in the GetCapabilities document, instead of just the range that the data spans.)", default=False)
     cache_last_updated = models.DateTimeField(null=True, editable=False)
     json = JSONField(blank=True, null=True, help_text="Arbitrary dataset-specific json blob")
-    slug = AutoSlugField(populate_from='name')
+    slug = AutoSlugField(populate_from='name', slugify=only_underscores)
 
     def __init__(self, *args, **kwargs):
         super(Dataset, self).__init__(*args, **kwargs)


### PR DESCRIPTION
This is required because JS variables can not have dashes in them, and we are still using `eval` in the Demo map.  Quick fix for a problem that should really be solved in the JS so datasets can be named whatever...
