### PR TITLE
Dockerfile +libkeyutils1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Dave Foster <dave@axiomdatascience.com>
 
 # Setup CONDA (https://hub.docker.com/r/continuumio/miniconda3/~/dockerfile/)
 RUN apt-get update && apt-get install -y wget bzip2 ca-certificates pwgen \
-    libglib2.0-0 libxext6 libsm6 libxrender1
+    libglib2.0-0 libxext6 libsm6 libxrender1 libkeyutils1
 RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
     wget --quiet https://repo.continuum.io/miniconda/Miniconda-3.10.1-Linux-x86_64.sh && \
     /bin/bash /Miniconda-3.10.1-Linux-x86_64.sh -b -p /opt/conda && \


### PR DESCRIPTION
looks like something changed with the debian/jessie image, at least with my builds

```
Step 14 : RUN python manage.py migrate --noinput
 ---> Running in 6136a86f6bf6
Traceback (most recent call last):
  File "manage.py", line 28, in <module>
    execute_from_command_line(sys.argv)
  File "/opt/conda/lib/python2.7/site-packages/django/core/management/__init__.py", line 385, in execute_from_command_line
    utility.execute()
  File "/opt/conda/lib/python2.7/site-packages/django/core/management/__init__.py", line 354, in execute
    django.setup()
  File "/opt/conda/lib/python2.7/site-packages/django/__init__.py", line 21, in setup
    apps.populate(settings.INSTALLED_APPS)
  File "/opt/conda/lib/python2.7/site-packages/django/apps/registry.py", line 108, in populate
    app_config.import_models(all_models)
  File "/opt/conda/lib/python2.7/site-packages/django/apps/config.py", line 202, in import_models
    self.models_module = import_module(models_module_name)
  File "/opt/conda/lib/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
  File "/srv/sci-wms/wms/models/__init__.py", line 8, in <module>
    from wms.models.datasets.netcdf import NetCDFDataset
  File "/srv/sci-wms/wms/models/datasets/netcdf.py", line 7, in <module>
    import netCDF4 as nc4
  File "/opt/conda/lib/python2.7/site-packages/netCDF4/__init__.py", line 3, in <module>
    from ._netCDF4 import *
ImportError: libkeyutils.so.1: cannot open shared object file: No such file or directory
```

adding libkeysutil1 fixes for me, if anyone can confirm, merge
